### PR TITLE
Fix tab issue, lets bundles get counted properly

### DIFF
--- a/awslimitchecker/services/workspaces.py
+++ b/awslimitchecker/services/workspaces.py
@@ -71,8 +71,8 @@ class _WorkspacesService(_AwsService):
             # Need the bundle information to determine workspace type
             for bundle in page['Bundles']:
                 bundles_map[bundle['BundleId']]=bundle['ComputeType']['Name']
-            # But also can count bundles
-            count_bundles += 1
+                # But also can count bundles
+                count_bundles += 1
 
         self.limits['Bundles']._add_current_usage(
             count_bundles,


### PR DESCRIPTION
When I added in "bundles" to the limit output (similar to workspaces, images, etc.), the count was off.  Turns out that this code was mis-aligned and python loves its tabs.  Fix the tabbing, and now the bundle count is more accurate.